### PR TITLE
修正为持仓天数为实际天数下一日执行

### DIFF
--- a/trader/seller_components.py
+++ b/trader/seller_components.py
@@ -54,7 +54,7 @@ class SwitchSeller(BaseSeller):
     def check_sell(self, code: str, quote: Dict, curr_date: str, curr_time: str, position: XtPosition,
                    held_day: int, max_price: Optional[float], history: Optional[pd.DataFrame]) -> bool:
 
-        if (held_day > self.switch_hold_days) and (self.switch_time_range[0] <= curr_time < self.switch_time_range[1]):
+        if (held_day >= self.switch_hold_days) and (self.switch_time_range[0] <= curr_time < self.switch_time_range[1]):
             curr_price = quote['lastPrice']
             cost_price = position.open_price
             sell_volume = position.can_use_volume


### PR DESCRIPTION
switch_hold_days 3天，实际购入当日天数为0，大于号表示持仓第5天才执行换仓卖出，跟理解不一致。 例如：17日（hold_day=0）买入，应当20日（hold_day=3）卖出，当前代码实际21日才执行换仓判断