### PR TITLE
更改卖出策略使用my_suber的cache

### DIFF
--- a/run_wencai.py
+++ b/run_wencai.py
@@ -199,7 +199,7 @@ def scan_buy(quotes: Dict, curr_date: str, positions: List) -> None:
 
 def scan_sell(quotes: Dict, curr_date: str, curr_time: str, positions: List) -> None:
     max_prices, held_days = update_max_prices(lock_of_disk_cache, quotes, positions, PATH_MAXP, PATH_HELD)
-    my_seller.execute_sell(quotes, curr_date, curr_time, positions, held_days, max_prices, cache_history)
+    my_seller.execute_sell(quotes, curr_date, curr_time, positions, held_days, max_prices, my_suber.cache_history)
 
 
 # ======== 框架 ========


### PR DESCRIPTION
run_wencai.py中的cache_history没有被赋值，一般都是空。且这里跟其他run_xx.py代码不一样，应该是误写。