### PR TITLE
check_orders方法支持传入cancelable_only参数

### DIFF
--- a/delegate/xt_delegate.py
+++ b/delegate/xt_delegate.py
@@ -163,9 +163,9 @@ class XtDelegate(BaseDelegate):
         else:
             raise Exception('xt_trader为空')
 
-    def check_orders(self) -> List[XtOrder]:
+    def check_orders(self, cancelable_only = False) -> List[XtOrder]:
         if self.xt_trader is not None:
-            return self.xt_trader.query_stock_orders(self.account, False)
+            return self.xt_trader.query_stock_orders(self.account, cancelable_only)
         else:
             raise Exception('xt_trader为空')
 


### PR DESCRIPTION
方便获取所有可以撤单的委托，以便要撤单的场景下快速获取委托信息