### PR TITLE
修正中签可转债返回数据中无信息导致today_hold_report异常退出问题

### DIFF
--- a/delegate/xt_subscriber.py
+++ b/delegate/xt_subscriber.py
@@ -334,7 +334,7 @@ class XtSubscriber:
                         curr_price = quotes[code]['lastPrice']
 
                     open_price = position.open_price
-                    if open_price == 0.0:
+                    if open_price == 0.0 or curr_price is None:
                         continue
 
                     vol = position.volume


### PR DESCRIPTION
today_hold_report函数中curr_price  为None情况后续 curr_price * vol 会抛出异常 unsupported operand type(s) for *: 'NoneType' and 'int'