### PR TITLE
增加save_json兼容性

### DIFF
--- a/tools/utils_cache.py
+++ b/tools/utils_cache.py
@@ -175,9 +175,9 @@ def load_json(path: str) -> dict:
 
 
 # 存储json缓存，全覆盖写入
-def save_json(path: str, var: dict) -> None:
+def save_json(path: str, var: dict, ensure_ascii=True) -> None:
     with open(path, 'w') as w:
-        w.write(json.dumps(var, indent=4))
+        w.write(json.dumps(var, ensure_ascii=ensure_ascii, indent=4))
 
 
 # 删除json缓存中的单个key-value，key为字符串


### PR DESCRIPTION
当key包含汉字时json.dumps会用unicode转义后表示汉字，用ensure_ascii=False直接控制用utf8存储汉字而不转义，增加json文件可读