### PR TITLE
修正use_outside_data 设置为True而use_ap_scheduler设置为False 情况

### DIFF
--- a/delegate/xt_subscriber.py
+++ b/delegate/xt_subscriber.py
@@ -92,6 +92,8 @@ class XtSubscriber(BaseSubscriber):
 
         self.use_outside_data = use_outside_data
         self.use_ap_scheduler = use_ap_scheduler
+        if self.use_outside_data:
+            self.use_ap_scheduler = True # 如果use_outside_data 被设置为True，则需强制使用apscheduler
 
         self.daily_reporter = DailyReporter(
             self.account_id,


### PR DESCRIPTION
这种情况下，start_scheduler_without_qmt_data()中self.scheduler未被初始化