### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,7 @@
 name: Run Tests
 
+permissions:
+  contents: read
 on: [push, pull_request]
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/silver6wings/SilverQuant/security/code-scanning/2](https://github.com/silver6wings/SilverQuant/security/code-scanning/2)

To fix the problem, add a `permissions` block that explicitly limits the GITHUB_TOKEN scope. This should be placed at the top of the workflow—before or after the `on:` block—so that it applies to all jobs, or alternatively inside the `test` job. The minimal starting point, as recommended, is `contents: read`. This allows actions to read repository contents but not perform write operations, which is appropriate since no steps in this workflow require write privilege. Only if uploading coverage to Codecov or any other step needs additional permissions should those be granted. For this workflow, add the following lines near the top:

```
permissions:
  contents: read
```

This change involves editing `.github/workflows/tests.yml`, inserting the block at the root level (after the name, before or after the `on:` block).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
