### PR TITLE
get_holding_position_count 函数添加参数only_stock 让返回持仓数可仅包含股票

### DIFF
--- a/delegate/xt_delegate.py
+++ b/delegate/xt_delegate.py
@@ -9,7 +9,7 @@ from xtquant.xttrader import XtQuantTrader
 from xtquant.xttype import StockAccount, XtPosition, XtOrder, XtAsset
 
 from credentials import *
-from tools.utils_basic import get_code_exchange
+from tools.utils_basic import get_code_exchange, is_stock
 from delegate.base_delegate import BaseDelegate
 from delegate.xt_callback import XtDefaultCallback
 
@@ -327,8 +327,11 @@ def is_position_holding(position: XtPosition) -> bool:
     return position.volume > 0
 
 
-def get_holding_position_count(positions: List[XtPosition]) -> int:
-    return sum(1 for position in positions if is_position_holding(position))
+def get_holding_position_count(positions: List[XtPosition], only_stock=False) -> int:
+    if only_stock:
+        return sum(1 for position in positions if is_stock(position.stock_code) and is_position_holding(position))
+    else:
+        return sum(1 for position in positions if is_position_holding(position))
 
 
 def xt_stop_exit():


### PR DESCRIPTION
run_xx,py 程序中scan_buy可修改如下来调整仓位计数仅股票，避免etf、逆回购导致的不准确。
    if len(selections) > 0:
        position_codes = [position.stock_code for position in positions]
        position_count = get_holding_position_count(positions, only_stock=True)