### PR TITLE
修正mootdx获取复权数据时问题：如当天为除权除息日实际上昨天数据并没有进行除权计算

### DIFF
--- a/tools/utils_remote.py
+++ b/tools/utils_remote.py
@@ -386,10 +386,23 @@ def get_mootdx_daily_history(
                 xdxr['datetime'] = pd.to_datetime(xdxr['date_str'] + ' 15:00:00')
                 xdxr = xdxr.set_index('datetime')
 
+                is_appended = False
+                xdxr_info = xdxr.loc[xdxr['category'] == 1]
+                now = datetime.datetime.now()
+                curr_date = now.strftime("%Y-%m-%d")
+                if not xdxr_info.empty and xdxr_info.index[-1].date() == now.date():
+                    last_row = df.iloc[-1].copy()
+                    last_row['datetime'] = curr_date
+                    df.loc[len(df)] = last_row
+                    df.index = pd.to_datetime(df['datetime'].astype(str), errors="coerce")
+                    is_appended  = True
+                
                 if adjust == ExitRight.QFQ:
                     df = make_qfq(df, xdxr)
                 elif adjust == ExitRight.HFQ:
                     df = make_hfq(df, xdxr)
+                if is_appended  == True:
+                    df = df[:-1]
         except Exception as e:
             print(f' mootdx get xdxr {code} error: ', e)
             return None


### PR DESCRIPTION
9月26日除权，原代码9月25日除权计算后open等值都不对。
测试验证：
    now = datetime.datetime.now()
    forward_day = 1  # 不算今天
    start_date = get_prev_trading_date(now, forward_day + 120)
    end_date = get_prev_trading_date(now, forward_day)
    code = '600633.SH'
    default_columns: list[str] = ['datetime', 'open', 'high', 'low', 'close', 'volume', 'amount']
    df = get_mootdx_daily_history(code, start_date, end_date,default_columns,ExitRight.QFQ)
    print(df[-1:])