### PR TITLE
给XtDelegate添加is_open_day，用于控制是否应该重连QMT

### DIFF
--- a/delegate/xt_delegate.py
+++ b/delegate/xt_delegate.py
@@ -37,6 +37,7 @@ class XtDelegate(BaseDelegate):
         super().__init__()
         self.ding_messager = ding_messager
         self.stock_names = StockNames()
+        self.is_open_day = True # 默认交易日
 
         self.xt_trader: Optional[XtQuantTrader] = None
 
@@ -90,7 +91,7 @@ class XtDelegate(BaseDelegate):
         return self.xt_trader, True
 
     def reconnect(self) -> None:
-        if self.xt_trader is None:
+        if self.xt_trader is None and self.is_open_day == True: # 仅交易日重连
             print('开始重连交易接口')
             _, success = self.connect(self.callback)
             if success:

--- a/delegate/xt_subscriber.py
+++ b/delegate/xt_subscriber.py
@@ -496,7 +496,7 @@ class XtSubscriber(BaseSubscriber):
             random_minute = random.randint(0, 10) + 5
             self.scheduler.add_job(self.finish_trade_day_wrapper, 'cron', hour=16, minute=random_minute)
 
-        self.scheduler.add_job(prev_check_open_day, 'cron', hour=1, minute=0, second=0)
+        self.scheduler.add_job(self.prev_check_open_day, 'cron', hour=1, minute=0, second=0)
         self.scheduler.add_job(self.callback_open_no_quotes, 'cron', hour=9, minute=14, second=59)
         self.scheduler.add_job(self.callback_close_no_quotes, 'cron', hour=11, minute=30, second=0)
         self.scheduler.add_job(self.callback_open_no_quotes, 'cron', hour=12, minute=59, second=59)
@@ -520,7 +520,7 @@ class XtSubscriber(BaseSubscriber):
 
         # 默认定时任务列表
         cron_jobs = [
-            ['01:00', prev_check_open_day, None],
+            ['01:00', self.prev_check_open_day, None],
             ['09:15', self.subscribe_tick, None],
             ['11:30', self.unsubscribe_tick, (True, )],
             ['13:00', self.subscribe_tick, (True, )],
@@ -625,15 +625,16 @@ class XtSubscriber(BaseSubscriber):
             #     self.delegate.shutdown()
 
 
-# -----------------------
-# 检查是否交易日
-# -----------------------
-def prev_check_open_day():
-    now = datetime.datetime.now()
-    curr_date = now.strftime('%Y-%m-%d')
-    curr_time = now.strftime('%H:%M')
-    print(f'[{curr_time}]', end='')
-    check_is_open_day(curr_date)
+    # -----------------------
+    # 检查是否交易日
+    # -----------------------
+    def prev_check_open_day(self):
+        now = datetime.datetime.now()
+        curr_date = now.strftime('%Y-%m-%d')
+        curr_time = now.strftime('%H:%M')
+        print(f'[{curr_time}]', end='')
+        is_open_day = check_is_open_day(curr_date)
+        self.delegate.is_open_day = is_open_day
 
 
 # -----------------------


### PR DESCRIPTION
QMT可以通过外部计划任务启动或者代码启动，非交易日代码会不断重连minitqmt。添加is_open_day用于上层代码来控制是否重连。
另外，prev_check_open_day 作为XtSubscriber 内部方法，应当改为XtSubscriber类的方法，且这里方便控制is_open_day，确保XtSubscriber层面代码逻辑不会混乱。